### PR TITLE
Build binderized Gatekeeper HAL

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -184,6 +184,12 @@ PRODUCT_PACKAGES += \
     mm-qcamera-app \
     Snap
 
+# new gatekeeper HAL
+PRODUCT_PACKAGES += \
+    android.hardware.gatekeeper@1.0-impl \
+    android.hardware.gatekeeper@1.0-service
+
+#KeyMaster HAL
 PRODUCT_PACKAGES += \
     android.hardware.keymaster@3.0-impl \
     android.hardware.keymaster@3.0-service \

--- a/manifest.xml
+++ b/manifest.xml
@@ -18,6 +18,15 @@
         </interface>
     </hal>
     <hal format="hidl">
+        <name>android.hardware.gatekeeper</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IGatekeeper</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
         <name>android.hardware.nfc</name>
         <transport>hwbinder</transport>
         <version>1.0</version>


### PR DESCRIPTION
According to this https://source.android.com/security/authentication/gatekeeper the gatekeeper hal is responsible for pattern/password authentication. Could fix an issue with timeouts happening when setting screen protected lockscreen.

Not tested